### PR TITLE
Bump puppet-boxen to remove repo URL hack

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -16,7 +16,7 @@ end
 # Includes many of our custom types and providers, as well as global
 # config. Required.
 
-github "boxen", "1.0.2"
+github "boxen", "1.1.1"
 
 # Core modules for a basic development environment. You can replace
 # some/most of these if you want, but it's not recommended.

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -6,7 +6,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: boxen/puppet-boxen
   specs:
-    boxen (1.0.2)
+    boxen (1.1.1)
 
 GITHUBTARBALL
   remote: boxen/puppet-caffeine
@@ -190,7 +190,7 @@ GITHUBTARBALL
 
 DEPENDENCIES
   alfred (= 1.0.1)
-  boxen (= 1.0.2)
+  boxen (= 1.1.1)
   caffeine (= 1.0.0)
   chrome (= 1.0.0)
   clojure (= 1.0.0)

--- a/modules/repo/manifests/alphagov.pp
+++ b/modules/repo/manifests/alphagov.pp
@@ -1,12 +1,5 @@
 define repo::alphagov {
   repository { "${boxen::config::srcdir}/${title}":
-    # this is a nasty nasty hack around the puppet-repository defined
-    # type. The regex used to detect whether the repo needs to be qualified
-    # is /\A\S+\/\S+\z/ which will match git@github.com:alphagov/$title and
-    # will try to prepend https://github.com/ to it - which is wrong. By
-    # starting my repo with a ' ' it is still valid for the git clone but
-    # fails the regex. I hate myself.
-    # https://github.com/boxen/puppet-repository/blob/master/lib/puppet/provider/repository/git.rb#LC55
-    source   => " git@github.com:alphagov/${title}",
+    source   => "git@github.com:alphagov/${title}",
   }
 }

--- a/modules/repo/manifests/gds.pp
+++ b/modules/repo/manifests/gds.pp
@@ -1,12 +1,5 @@
 define repo::gds {
   repository { "${boxen::config::srcdir}/${title}":
-    # this is a nasty nasty hack around the puppet-repository defined
-    # type. The regex used to detect whether the repo needs to be qualified
-    # is /\A\S+\/\S+\z/ which will match git@github.com:alphagov/$title and
-    # will try to prepend https://github.com/ to it - which is wrong. By
-    # starting my repo with a ' ' it is still valid for the git clone but
-    # fails the regex. I hate myself.
-    # https://github.com/boxen/puppet-repository/blob/master/lib/puppet/provider/repository/git.rb#LC55
-    source   => " git@github.gds:gds/${title}",
+    source   => "git@github.gds:gds/${title}",
   }
 }


### PR DESCRIPTION
The regex for repo URLs has been modified to allow non https://github.com
resources. We can remove our minor hack and @samjsharpe can sleep easy.

```
https://github.com/boxen/puppet-boxen/pull/5
```
