### PR TITLE
Revert "Remove full-disk-encryption requirement"

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -55,9 +55,9 @@ node default {
   include ruby
 
   # fail if FDE is not enabled
-  #if $::root_encrypted == 'no' {
-  #  fail('Please enable full disk encryption and try again')
-  #}
+  if $::root_encrypted == 'no' {
+    fail('Please enable full disk encryption and try again')
+  }
 
   # node versions
   include nodejs::0-4


### PR DESCRIPTION
This reverts commit 0afcaf21c1cd5afe2feb643b7d7d761032fab07b.

New OSX builds from IT now use FV2 instead of PGP. Because Boxen requires
Mountain Lion there's a good chance, one way or another, everyone has FV2.
Thus we should enforce this sensible default.
## 

Speak now if this affects you adversely. Or forever hold your peace.
