### PR TITLE
Bump puppet-boxen from 1.3.0 to 2.3.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -21,19 +21,20 @@ github "boxen", "2.3.1"
 # Core modules for a basic development environment. You can replace
 # some/most of these if you want, but it's not recommended.
 
-github "dnsmasq",  "1.0.0"
-github "gcc",      "1.0.0"
-mod    "git",      :ref => "fix-git-options", :git => "https://github.com/bradleywright/puppet-git"
-github "homebrew", "1.1.2"
-github "hub",      "1.0.0"
-github "inifile",  "0.9.0", :repo => "cprice-puppet/puppetlabs-inifile"
-github "java",     "1.1.0"
-github "nginx",    "1.1.0"
-github "nodejs",   "1.0.0"
-github "nvm",      "1.0.0"
-github "ruby",     "4.1.0"
-github "stdlib",   "4.0.0", :repo => "puppetlabs/puppetlabs-stdlib"
-github "sudo",     "1.0.0"
+github "dnsmasq",    "1.0.0"
+github "gcc",        "1.0.0"
+mod    "git",        :ref => "fix-git-options", :git => "https://github.com/bradleywright/puppet-git"
+github "homebrew",   "1.1.2"
+github "hub",        "1.0.0"
+github "inifile",    "0.9.0", :repo => "cprice-puppet/puppetlabs-inifile"
+github "java",       "1.1.0"
+github "nginx",      "1.1.0"
+github "nodejs",     "1.0.0"
+github "nvm",        "1.0.0"
+github "repository", "2.2.0"
+github "ruby",       "4.1.0"
+github "stdlib",     "4.0.0", :repo => "puppetlabs/puppetlabs-stdlib"
+github "sudo",       "1.0.0"
 
 # Optional/custom modules. There are tons available at
 # https://github.com/boxen.

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -161,6 +161,11 @@ GITHUBTARBALL
     qt (1.0.0)
 
 GITHUBTARBALL
+  remote: boxen/puppet-repository
+  specs:
+    repository (2.2.0)
+
+GITHUBTARBALL
   remote: boxen/puppet-ruby
   specs:
     ruby (4.1.0)
@@ -406,6 +411,7 @@ DEPENDENCIES
   property_list_key (= 0.1.0)
   pycharm (= 1.0.1)
   qt (= 1.0.0)
+  repository (= 2.2.0)
   ruby (= 4.1.0)
   rubymine (= 1.0.1)
   screen (= 1.0.0)
@@ -427,3 +433,4 @@ DEPENDENCIES
   xquartz (= 1.0.0)
   xtrafinder (= 1.0.1)
   zsh (= 1.0.0)
+


### PR DESCRIPTION
This adds a bunch of new Puppet types and some other improvements.

[Full list](https://github.com/boxen/puppet-boxen/compare/1.3.0...2.3.1)

Currently untested as I'm on my home machine.
