### PR TITLE
Add OmniFocus app

### DIFF
--- a/modules/omnifocus/manifests/init.pp
+++ b/modules/omnifocus/manifests/init.pp
@@ -1,0 +1,11 @@
+# Public: Install Omnifocus.app into /Applications.
+#
+# Examples
+#
+#   include omnifocus
+class omnifocus {
+  package { 'OmniFocus':
+    provider => 'appdmg_eula',
+    source   => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.6/OmniFocus-1.10.4.dmg'
+  }
+}


### PR DESCRIPTION
This requires the `appdmg_eula` type, which is present in puppet-boxen 2.3.1, which is in #9.
