### PR TITLE
remove %r (remote user) from ssh_config ProxyCommands

### DIFF
--- a/modules/gds-ssh-config/templates/config.erb
+++ b/modules/gds-ssh-config/templates/config.erb
@@ -10,7 +10,7 @@ Host jumpbox-2.management.preview
   ProxyCommand none
 
 Host *.preview
-  ProxyCommand ssh -e none %r@jumpbox-1.management.preview exec nc $(echo %h | sed 's/\.preview$/\.production/') %p
+  ProxyCommand ssh -e none jumpbox-1.management.preview exec nc $(echo %h | sed 's/\.preview$/\.production/') %p
 
 
 # Staging
@@ -25,7 +25,7 @@ Host jumpbox-2.management.staging
   ProxyCommand none
 
 Host *.staging
-  ProxyCommand ssh -e none %r@jumpbox-1.management.staging exec nc $(echo %h | sed 's/\.staging$/\.production/') %p
+  ProxyCommand ssh -e none jumpbox-1.management.staging exec nc $(echo %h | sed 's/\.staging$/\.production/') %p
 
 
 # Production
@@ -40,6 +40,6 @@ Host jumpbox-2.management.production
   ProxyCommand none
 
 Host *.production
-  ProxyCommand ssh -e none %r@jumpbox-1.management.production exec nc %h %p
+  ProxyCommand ssh -e none jumpbox-1.management.production exec nc %h %p
 
 <%= extra %>


### PR DESCRIPTION
The usage of %r here has the effect of presenting the same user to the
jumpbox as the target machine. That is, if I type the command

```
$ ssh ubuntu@foo.bar.preview
```

it will use a ProxyCommand which goes via
ubuntu@jumpbox-1.management.preview. This is not generally what I want
-- if I'm specifying a user, I want that user to apply only to the
target machine, not to the jumpbox in the ProxyCommand, since I
probably _don't_ have credentials to run as
ubuntu@jumpbox-1.management.preview.

Also, ruby's Net::SSH reads the user .ssh/config file but while it
understands %h and %p, it doesn't understand the %r option. This
breaks the vcloud-provisioner.
