### PR TITLE
Use @ for argument in ssh config template

### DIFF
--- a/modules/gds-ssh-config/templates/config.erb
+++ b/modules/gds-ssh-config/templates/config.erb
@@ -42,4 +42,4 @@ Host jumpbox-2.management.production
 Host *.production
   ProxyCommand ssh -e none %r@jumpbox-1.management.production exec nc %h %p
 
-<%= extra %>
+<%= @extra %>


### PR DESCRIPTION
The previous syntax is deprecated.
