### PR TITLE
Add vagrant-cachier to gds-development

### DIFF
--- a/modules/gds-development/manifests/init.pp
+++ b/modules/gds-development/manifests/init.pp
@@ -12,6 +12,8 @@ class gds-development {
   include vagrant
   include virtualbox
 
+  # Use the vagrant cachier plugin to cache apt downloads
+  vagrant::plugin { 'vagrant-cachier': }
   # Dev uses the vagrant-dns plugin
   vagrant::plugin { 'vagrant-dns': }
 


### PR DESCRIPTION
This should probably be a default in both here and our Vagrantfile, to
speed up provisioning.
