### PR TITLE
Recommend installing Command Line Tools via the full Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ## Getting started with Boxen
 
 - Make sure you are running Mac OS X 10.8 (Mountain Lion)
-- Either install the [Xcode Command Line Tools][xcode-cli] or install the full Xcode from the Mac App Store. If you do the latter, you also need to explicitly install the Command Line Tools (Open Xcode -> Preferences -> Downloads -> Install Command Line Tools).
+- Install the full Xcode from the Mac App Store, and then explicitly install the Command Line Tools (Open Xcode -> Preferences -> Downloads -> Install Command Line Tools). You may instead be able to use the [standalone Xcode Command Line Tools][xcode-cli] rather than installing it through the full Xcode, but this has caused some issues and [Boxen's README][boxen-readme] recommends using the full Xcode. You might also need to run `sudo xcode-select --switch [/path/to/xcode]` to select the version of Xcode to use.
 [xcode-cli]: https://developer.apple.com/downloads/index.action
+[boxen-readme]: https://github.com/boxen/our-boxen/blob/master/README.md#getting-started
 
 ### The following instructions will work for a fresh build or for an already set-up Mac.
 


### PR DESCRIPTION
I came across some issues trying to use the standalone Xcode Command Line Tools (as explained here), and Boxen now recommends using it through full Xcode, so this adds this recommendation to our README.

Does anyone know whether setting `sudo xcode-select --switch /path/to/xcode` is necessary when initially using full Xcode? I had to do that after installing it, but setting it to `/` during my previous adventures with the standalone version may have confused the situation...
