### PR TITLE
Set up passwordless sudo for tuntap-installer

### DIFF
--- a/modules/openconnect/manifests/init.pp
+++ b/modules/openconnect/manifests/init.pp
@@ -1,5 +1,14 @@
 class openconnect {
 
+    sudoers { 'tuntap-installer':
+      users    => $::boxen_user,
+      hosts    => 'ALL',
+      commands => [
+      '(ALL) NOPASSWD : /usr/bin/tuntap-installer',
+      ],
+      type     => 'user_spec',
+     }
+
     package { 'openconnect':
       ensure => present,
     }
@@ -19,6 +28,7 @@ class openconnect {
     exec {'install-tuntap':
       command     => 'sudo /usr/bin/tuntap-installer',
       refreshonly => true,
+      require     => Sudoers['tuntap-installer'],
     }
 
 }


### PR DESCRIPTION
This means that openconnect will be able to work after install without a
manual run of tuntap-installer
