### PR TITLE
Build gems for ruby-2.0.0

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -81,6 +81,13 @@ define ruby::all::gem (
     require => Ruby::Version['1.9.3'],
     version => $version,
   }
+  ruby::gem {"${name}-2.0.0":
+    ensure => $ensure,
+    gem     => $name,
+    ruby    => '2.0.0',
+    require => Ruby::Version['2.0.0'],
+    version => $version,
+  }
 }
 
 node default {


### PR DESCRIPTION
This PR adds ruby-2.0.0 to the `ruby::all::gem` define, such that it will
compile and install the gem for ruby 2.0.0 I've tested this with the `zeus`
gem, but it might not work for all gems.

I'd appreciate some testing of by anyone who uses the following classes:
- gds-development
- git-pulls
- git-remote-branch
- github_gem
- travis
- vagrant-dns
- vagrant-vbguest
- vagrant_gem
- zeus
