### PR TITLE
Update Alfred 2 to 2.1.1_227

### DIFF
--- a/modules/alfred/manifests/two.pp
+++ b/modules/alfred/manifests/two.pp
@@ -6,6 +6,6 @@
 class alfred::two {
   package { 'Alfred 2':
     provider => 'compressed_app',
-    source   => 'http://cachefly.alfredapp.com/Alfred_2.0.1_173.zip'
+    source   => 'http://cachefly.alfredapp.com/Alfred_2.1.1_227.zip'
   }
 }


### PR DESCRIPTION
This upgrades Alfred2 from 2.0.1_173 to 2.1.1_227.

Changelog: http://www.alfredapp.com/changelog

Particularly affects @alexmuller, @benilovj, @bradleywright, @bruntonspall and @samjsharpe.
