### PR TITLE
Rename `emacs-keybindings` to comply with linting

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -79,7 +79,7 @@ mod    "concat",         "1.0.0",
 github "controlplane",   "1.1.0", :repo => "dieterdemeyer/puppet-controlplane"
 github "dropbox",        "1.2.0"
 github "emacs",          "1.1.6", :repo => "bradleywright/puppet-emacs"
-github "emacs-keybindings", "1.0.0", :repo => "bradleywright/puppet-emacs-keybindings"
+github "emacs_keybindings", "2.0.0", :repo => "bradleywright/puppet-emacs-keybindings"
 github "evernote",       "2.0.5"
 github "firefox",        "1.1.8"
 github "flux",           "1.0.0"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -343,7 +343,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: bradleywright/puppet-emacs-keybindings
   specs:
-    emacs-keybindings (1.0.0)
+    emacs_keybindings (2.0.0)
 
 GITHUBTARBALL
   remote: bradleywright/puppet-stay
@@ -461,7 +461,7 @@ DEPENDENCIES
   dnsmasq (= 1.0.1)
   dropbox (= 1.2.0)
   emacs (= 1.1.6)
-  emacs-keybindings (= 1.0.0)
+  emacs_keybindings (= 2.0.0)
   evernote (= 2.0.5)
   firefox (= 1.1.8)
   flux (= 1.0.0)

--- a/modules/people/manifests/bradleywright.pp
+++ b/modules/people/manifests/bradleywright.pp
@@ -4,7 +4,7 @@ class people::bradleywright {
   include chrome
   include dropbox
   include emacs::head
-  include emacs-keybindings
+  include emacs_keybindings
   include gds_osx::remove_spotlight
   include gds_osx::turn_off_dashboard
   include gds_vpn_profiles

--- a/modules/people/manifests/philandstuff.pp
+++ b/modules/people/manifests/philandstuff.pp
@@ -1,7 +1,7 @@
 class people::philandstuff {
   include caffeine
   include emacs::formacosx
-  include emacs-keybindings
+  include emacs_keybindings
   include iterm2::stable
   include openconnect
   include sizeup


### PR DESCRIPTION
This updates the old `emacs-keybindings` module to be named `emacs_keybindings`.

Affects my own manifest, and that of @philandstuff, which I've updated as part of this pull request.
