### PR TITLE
Stop using netcat to forward SSH

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -10,7 +10,7 @@ Host jumpbox-2.management.preview
   ProxyCommand none
 
 Host *.preview
-  ProxyCommand ssh -e none %r@jumpbox-1.management.preview exec nc $(echo %h | sed 's/\.preview$/\.production/') %p
+  ProxyCommand ssh -e none %r@jumpbox-1.management.preview -W $(echo %h | sed 's/\.preview$/\.production/'):%p
 
 
 # Staging
@@ -25,7 +25,7 @@ Host jumpbox-2.management.staging
   ProxyCommand none
 
 Host *.staging
-  ProxyCommand ssh -e none %r@jumpbox-1.management.staging exec nc $(echo %h | sed 's/\.staging$/\.production/') %p
+  ProxyCommand ssh -e none %r@jumpbox-1.management.staging -W $(echo %h | sed 's/\.staging$/\.production/'):%p
 
 
 # Production
@@ -40,4 +40,4 @@ Host jumpbox-2.management.production
   ProxyCommand none
 
 Host *.production
-  ProxyCommand ssh -e none %r@jumpbox-1.management.production exec nc %h %p
+  ProxyCommand ssh -e none %r@jumpbox-1.management.production -W %h:%p


### PR DESCRIPTION
New versions of SSH (5.4+) support the `-W` flag to forward connections. Given Boxen requires Mountain Lion or above we can assume this will work on our development Macs.

Thanks to @calpaterson for the original idea.
