### PR TITLE
Only remove the internal tld when sedding

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -10,7 +10,7 @@ Host jumpbox-2.management.preview
   ProxyCommand none
 
 Host *.preview
-  ProxyCommand ssh -e none %r@jumpbox-1.management.preview -W $(echo %h | sed 's/\.preview$/\.production/'):%p
+  ProxyCommand ssh -e none %r@jumpbox-1.management.preview -W $(echo %h | sed 's/\.preview$//'):%p
 
 
 # Staging
@@ -25,7 +25,7 @@ Host jumpbox-2.management.staging
   ProxyCommand none
 
 Host *.staging
-  ProxyCommand ssh -e none %r@jumpbox-1.management.staging -W $(echo %h | sed 's/\.staging$/\.production/'):%p
+  ProxyCommand ssh -e none %r@jumpbox-1.management.staging -W $(echo %h | sed 's/\.staging$//'):%p
 
 
 # Production
@@ -40,4 +40,4 @@ Host jumpbox-2.management.production
   ProxyCommand none
 
 Host *.production
-  ProxyCommand ssh -e none %r@jumpbox-1.management.production -W %h:%p
+  ProxyCommand ssh -e none %r@jumpbox-1.management.production -W $(echo %h | sed 's/\.production$//'):%p


### PR DESCRIPTION
Our hosts file has aliases for each host without the internal tld. So there is 
no need to replace the internal tld we can just remove it.

Also make production the same as the other environments.

_This probably needs testing on a mac_
