### PR TITLE
Add Carrenza secure VPN profile

### DIFF
--- a/modules/gds_vpn_profiles/files/profile/carrenza_secure.xml
+++ b/modules/gds_vpn_profiles/files/profile/carrenza_secure.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnyConnectProfile xmlns="http://schemas.xmlsoap.org/encoding/">
+  <ServerList>
+    <HostEntry>
+      <HostName>Carrenza - Secure</HostName>
+      <HostAddress>https://secure.carrenza.com</HostAddress>
+      <PrimaryProtocol>SSL</PrimaryProtocol>
+    </HostEntry>
+  </ServerList>
+</AnyConnectProfile>


### PR DESCRIPTION
This commit adds the secure VPN profile details to Boxen. Authentication is
by way of TOTP token and passphrase - details can be found on the opsmanual.
