### PR TITLE
Stop using netcat to forward SSH

### DIFF
--- a/modules/teams/templates/performance-platform/ssh-config
+++ b/modules/teams/templates/performance-platform/ssh-config
@@ -7,7 +7,7 @@ Host jumpbox.preview.performance.service.gov.uk
   ProxyCommand none
 
 Host *.pp-preview
-  ProxyCommand ssh -e none %r@jumpbox.preview.performance.service.gov.uk exec nc $(echo %h | sed 's/\.pp-preview$//') %p
+  ProxyCommand ssh -e none %r@jumpbox.preview.performance.service.gov.uk -W $(echo %h | sed 's/\.pp-preview$//'):%p
 
 #
 # Performance Platform Staging
@@ -18,7 +18,7 @@ Host jumpbox.staging.performance.service.gov.uk
   ProxyCommand none
 
 Host *.pp-staging
-  ProxyCommand ssh -e none %r@jumpbox.staging.performance.service.gov.uk exec nc $(echo %h | sed 's/\.pp-staging$//') %p
+  ProxyCommand ssh -e none %r@jumpbox.staging.performance.service.gov.uk -W $(echo %h | sed 's/\.pp-staging$//'):%p
 
 #
 # Performance Platform Production
@@ -29,4 +29,4 @@ Host jumpbox.production.performance.service.gov.uk
   ProxyCommand none
 
 Host *.pp-production
-  ProxyCommand ssh -e none %r@jumpbox.production.performance.service.gov.uk exec nc $(echo %h | sed 's/\.pp-production$//') %p
+  ProxyCommand ssh -e none %r@jumpbox.production.performance.service.gov.uk -W $(echo %h | sed 's/\.pp-production$//'):%p


### PR DESCRIPTION
New versions of SSH (5.4+) support the `-W` flag to forward connections. Given
Boxen requires Mountain Lion or above we can assume this will work on our
development Macs.
