### PR TITLE
Remove ControlPlane

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -76,7 +76,6 @@ github "clojure",        "1.2.0"
 mod    "concat",         "1.0.0",
   :git => "git://github.com/puppetlabs/puppetlabs-concat.git",
   :ref => '1.0.0'
-github "controlplane",   "1.1.0", :repo => "dieterdemeyer/puppet-controlplane"
 github "dropbox",        "1.2.0"
 github "emacs",          "1.1.6", :repo => "bradleywright/puppet-emacs"
 github "emacs_keybindings", "2.0.0", :repo => "bradleywright/puppet-emacs-keybindings"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -361,11 +361,6 @@ GITHUBTARBALL
     adium (1.3.0)
 
 GITHUBTARBALL
-  remote: dieterdemeyer/puppet-controlplane
-  specs:
-    controlplane (1.1.0)
-
-GITHUBTARBALL
   remote: dieterdemeyer/puppet-github_for_mac
   specs:
     github_for_mac (1.4.0)
@@ -457,7 +452,6 @@ DEPENDENCIES
   chrome (= 1.1.2)
   clojure (= 1.2.0)
   concat (= 1.0.0)
-  controlplane (= 1.1.0)
   dnsmasq (= 1.0.1)
   dropbox (= 1.2.0)
   emacs (= 1.1.6)


### PR DESCRIPTION
The referenced GitHub repository no longer exists, which causes dependency installation to fail.

As far as I can tell nobody is using this.
