### PR TITLE
Bump Vagrant to 1.5.3

### DIFF
--- a/modules/gds_development/manifests/init.pp
+++ b/modules/gds_development/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #  include gds_development
 #
-class gds_development($version = '1.4.2') {
+class gds_development($version = '1.5.3') {
   # Puppet is used to make VMs
   include projects::puppet
 


### PR DESCRIPTION
1.4.x is broken - the download URL changed after 1.4, which got broken [on this change](https://github.com/boxen/puppet-vagrant/commit/ef3921a8db039407e03f3e67443ae57dd31316f1#diff-60ae41fd0a31977447947f59940ee9a4L10), and 1.5.3 is the last stable upgrade pre-1.6.0.

Given Vagrant is often unstable early in development cycles I thought it prudent to pin it to the last previous version rather than 1.6.x latest.

See #91 for more details.
