### PR TITLE
Remove encfs and gnupg modules

### DIFF
--- a/modules/encfs/manifests/init.pp
+++ b/modules/encfs/manifests/init.pp
@@ -1,5 +1,0 @@
-class encfs {
-  package { 'encfs':
-    ensure  => present,
-  }
-}

--- a/modules/gnupg/manifests/init.pp
+++ b/modules/gnupg/manifests/init.pp
@@ -1,5 +1,0 @@
-class gnupg {
-  package { 'gnupg':
-    ensure => present,
-  }
-}

--- a/modules/people/manifests/ajlanghorn.pp
+++ b/modules/people/manifests/ajlanghorn.pp
@@ -2,7 +2,6 @@ class people::ajlanghorn {
   include adium
   include caffeine
   include chrome
-  include encfs
   include gds_resolver
   include gds_vpn_profiles
   include git

--- a/modules/people/manifests/annashipman.pp
+++ b/modules/people/manifests/annashipman.pp
@@ -1,10 +1,8 @@
 class people::annashipman {
   include chrome
-  include encfs
   include gds_osx::turn_off_dashboard
   include gds_vpn_profiles
   include git
-  include gnupg
   include iterm2::stable
   include libreoffice
   include vagrant

--- a/modules/people/manifests/bruntonspall.pp
+++ b/modules/people/manifests/bruntonspall.pp
@@ -4,14 +4,12 @@ class people::bruntonspall {
   include caffeine
   include chrome
   include dropbox
-  include encfs
   include gds_osx::turn_off_dashboard
   include gds_resolver
   include java
   include intellij
   include iterm2::dev
   include git
-  include gnupg
   include gitx::dev
   include sublime_text_2
   include vagrant
@@ -61,6 +59,8 @@ class people::bruntonspall {
 
   package {
     [
+      'encfs',
+      'gnupg',
       'offline-imap',
       'app-engine-java-sdk',
       'mutt',

--- a/modules/people/manifests/carlmassa.pp
+++ b/modules/people/manifests/carlmassa.pp
@@ -5,7 +5,6 @@ class people::carlmassa {
   include gds_resolver
   include github_for_mac
   include gitx::dev
-  include gnupg
   include googledrive
   include hub
   include iterm2::stable

--- a/modules/people/manifests/jennyd.pp
+++ b/modules/people/manifests/jennyd.pp
@@ -1,13 +1,11 @@
 class people::jennyd {
   include chrome
   include dropbox
-  include encfs
   include gds_development
   include gds_osx::turn_off_dashboard
   include gds_resolver
   include gds_ssh_config
   include gds_vpn_profiles
-  include gnupg
   include iterm2::stable
   include skype
   include sublime_text_2

--- a/modules/people/manifests/mattbostock.pp
+++ b/modules/people/manifests/mattbostock.pp
@@ -8,7 +8,6 @@ class people::mattbostock {
   include gds_vpn_profiles
   include git
   include gitx
-  include gnupg
   include mysql
   include openconnect
   include screen

--- a/modules/people/manifests/rjw1.pp
+++ b/modules/people/manifests/rjw1.pp
@@ -1,11 +1,9 @@
 class people::rjw1 {
   include chrome
   include firefox
-  include encfs
   include gds_vpn_profiles
   include openconnect
   include git
-  include gnupg
   include iterm2::stable
   include vagrant
   include gds_virtualbox

--- a/modules/people/manifests/samjsharpe/packages.pp
+++ b/modules/people/manifests/samjsharpe/packages.pp
@@ -7,7 +7,6 @@ class people::samjsharpe::packages {
   include gds_resolver
   include gds_vpn_profiles
   include googledrive
-  include gnupg
   include hub
   include iterm2::stable
   include macvim
@@ -59,6 +58,7 @@ PROMPT=\'$(virtualenv_prompt_info)%{$reset_color%}[%{$fg[cyan]%}%2d$(git_prompt_
       'encfs',
       'fping',
       'gpg-agent',
+      'gnupg',
       'heroku-toolbelt',
       'htop-osx',
       'nmap',

--- a/modules/projects/manifests/deployment/creds.pp
+++ b/modules/projects/manifests/deployment/creds.pp
@@ -1,6 +1,8 @@
 # Deps for credential store within deployment repo.
 class projects::deployment::creds inherits projects::deployment {
-  include gnupg
-  include encfs
-  ensure_packages(['pwgen'])
+  ensure_packages([
+    'encfs',
+    'gnupg',
+    'pwgen',
+    ])
 }


### PR DESCRIPTION
They don’t pull their weight any more.

@annashipman, @ajlanghorn, @rjw1, @bruntonspall, @carlmassa, @jennyd, @mattbostock, @samjsharpe
