### PR TITLE
Remove older rubies

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -69,7 +69,6 @@ node default {
 
   # default ruby versions
   ruby::version {'1.8.7': }
-  ruby::version {'1.9.2': }
   ruby::version {'1.9.3': }
   ruby::version {'2.0.0': }
   ruby::version {'2.1.0': }


### PR DESCRIPTION
1.8.7 is ancient.

1.9.2 is buggy.

People will need to `rbenv uninstall` various things too.
