### PR TITLE
Update virtualbox version

### DIFF
--- a/modules/gds_virtualbox/manifests/recommended.pp
+++ b/modules/gds_virtualbox/manifests/recommended.pp
@@ -1,6 +1,6 @@
 class gds_virtualbox::recommended {
   package { 'VirtualBox':
     provider => 'pkgdmg',
-    source   => 'http://download.virtualbox.org/virtualbox/4.2.6/VirtualBox-4.2.6-82870-OSX.dmg'
+    source   => 'http://download.virtualbox.org/virtualbox/4.3.6/VirtualBox-4.3.6-91406-OSX.dmg'
   }
 }


### PR DESCRIPTION
Performance platform vms dont work on 4.2 - and I've been running the
govuk VMs on 4.3
