### PR TITLE
2.1.2 is the version available for production

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -72,7 +72,8 @@ node default {
   ruby::version {'1.9.3': }
   ruby::version {'2.0.0': }
   ruby::version {'2.1.0': }
-  ruby::version {'2.1.1': }
+  ruby::version {'2.1.1': ensure => 'absent'}
+  ruby::version {'2.1.2': }
 
   ruby_gem { 'bundler for all rubies':
     gem          => 'bundler',


### PR DESCRIPTION
Also remove 2.1.1 since it’s not something we run in production.
