### PR TITLE
Update VirtualBox to latest release

### DIFF
--- a/modules/gds_virtualbox/manifests/recommended.pp
+++ b/modules/gds_virtualbox/manifests/recommended.pp
@@ -1,6 +1,6 @@
 class gds_virtualbox::recommended {
   package { 'VirtualBox':
     provider => 'pkgdmg',
-    source   => 'http://download.virtualbox.org/virtualbox/4.3.6/VirtualBox-4.3.6-91406-OSX.dmg'
+    source   => 'http://download.virtualbox.org/virtualbox/4.3.14/VirtualBox-4.3.14-95030-OSX.dmg'
   }
 }


### PR DESCRIPTION
I was getting a VirtualBox error when importing our latest image.

```
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["import",
"/Users/bobwalker/.vagrant.d/boxes/govuk_dev_precise64_20140430/0/virtualbox/box.ovf",
"--vsys", "0", "--vmname", "govuk_dev_precise64_1409056507211_29045",
"--vsys", "0", "--unit", "9", "--disk", "/Users/bobwalker/VirtualBox
VMs/govuk_dev_precise64_1409056507211_29045/box-disk1.vmdk"]

Stderr: 0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Interpreting
/Users/bobwalker/.vagrant.d/boxes/govuk_dev_precise64_20140430/0/virtualbox/box.ovf...
OK.
0%...
Progress state: NS_ERROR_FAILURE
VBoxManage: error: Appliance import failed
VBoxManage: error: <vbox:Machine> element in OVF contains a medium
attachment for the disk image 4cb10378-12be-47ed-845f-8a04ef5a3107 but
the OVF describes no such image
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005),
component Appliance, interface IAppliance
VBoxManage: error: Context: "int handleImportAppliance(HandlerArg*)" at
line 781 of file VBoxManageAppliance.cpp

```

I fixed this by updating to the latest version.
