### PR TITLE
Replace packages for alphagov/packager repo

### DIFF
--- a/modules/teams/manifests/infrastructure.pp
+++ b/modules/teams/manifests/infrastructure.pp
@@ -11,7 +11,7 @@ class teams::infrastructure ($manage_gitconfig = true) {
   include projects::govuk_redirector-deployment
   include projects::govuk_redirector-puppet
   include projects::opsmanual
-  include projects::packages
+  include projects::packager
   include projects::private-utils
   include projects::puppet
   include projects::smokey


### PR DESCRIPTION
Removes the `packages` repo, which has been moved to the GDS attic.
