### PR TITLE
Update wireshark to 1.12.1

### DIFF
--- a/modules/wireshark/manifests/init.pp
+++ b/modules/wireshark/manifests/init.pp
@@ -1,4 +1,4 @@
-class wireshark($version='1.10.7') {
+class wireshark($version='1.12.1') {
   package { 'Wireshark':
     source   => "http://wiresharkdownloads.riverbed.com/wireshark/osx/Wireshark%20${version}%20Intel%2064.dmg",
     provider => 'pkgdmg',


### PR DESCRIPTION
The riverbed download for 1.10.7 no longer exists.
