### PR TITLE
Track new clients for performance platform

### DIFF
--- a/modules/teams/manifests/performance-platform.pp
+++ b/modules/teams/manifests/performance-platform.pp
@@ -42,7 +42,8 @@ class teams::performance-platform {
   repo::alphagov { 'gapy': }
   repo::alphagov { 'performance-datastore': }
   repo::alphagov { 'performanceplatform-admin': }
-  repo::alphagov { 'performanceplatform-client': }
+  repo::alphagov { 'performanceplatform-client.js': }
+  repo::alphagov { 'performanceplatform-client.py': }
   repo::alphagov { 'performanceplatform-collector': }
   repo::alphagov { 'performanceplatform-collector-config': }
   repo::alphagov { 'performanceplatform-notifier': }


### PR DESCRIPTION
Original one has been renamed with a .py suffix, and we have a .js one
now as well.

Should probably extract out the Go one in a library.
