### PR TITLE
[alexmuller] Add pre-commit hooks for all projects

### DIFF
--- a/modules/people/files/alexmuller/govuk-pre-commit-hooks
+++ b/modules/people/files/alexmuller/govuk-pre-commit-hooks
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+for dir in /Users/alexmuller/govuk/*/.git
+  do
+    if [[ ! -e $dir/hooks/pre-commit ]]
+      then
+        cat > "$dir/hooks/pre-commit" <<"MYHOOK"
+#!/usr/bin/env ruby
+
+# Testing the diff that's about to be committed for secrets
+
+full_diff = `git diff --cached --`.encode("UTF-8")
+
+added_code = full_diff.split("\n").select { |line| line.start_with?("+") }.join("\n")
+
+if added_code.match(/PRIVATE KEY/)
+  puts "It looks like there's a private key in the code that's about to be committed. Aborting."
+  exit 1
+end
+MYHOOK
+    fi
+    if [[ ! -x $dir/hooks/pre-commit ]]
+      then
+        chmod a+x "$dir/hooks/pre-commit"
+    fi
+done
+

--- a/modules/people/manifests/alexmuller.pp
+++ b/modules/people/manifests/alexmuller.pp
@@ -97,6 +97,12 @@ class people::alexmuller {
     source => 'puppet:///modules/people/alexmuller/bash_profile',
   }
 
+  # Install pre-commit hooks everywhere
+  file { "${home_directory}/govuk-pre-commit-hooks":
+    source => 'puppet:///modules/people/alexmuller/govuk-pre-commit-hooks',
+    mode   => 0755,
+  } -> exec { "${home_directory}/govuk-pre-commit-hooks": }
+
   sudoers { 'alexmuller_sudo':
     users    => $::boxen_user,
     type     => 'user_spec',


### PR DESCRIPTION
Install a pre-commit hook in all of my GOV.UK projects that checks for the string "PRIVATE KEY".

Feel free to use this if you would like to.