### PR TITLE
Add performance platform ssh config to the team

### DIFF
--- a/modules/teams/manifests/performance-platform.pp
+++ b/modules/teams/manifests/performance-platform.pp
@@ -26,6 +26,7 @@ class teams::performance-platform {
 
   # Performance Platform specific stuff
   include teams::performance-platform::puppet
+  include teams::performance-platform::ssh
 
   repo::gds      { 'google-dev-credentials': }
   repo::gds      { 'pp-manual': }


### PR DESCRIPTION
So new users dont have to add this to their personal manifest - adding
the team manifest should give you everything you need to get started.

The downside of this is users who have included this in their personal
manifests will have the definitions repeated twice - however this will
not affect functionality