### PR TITLE
Change `projects::redirector` to `projects::transition-config` to reflect the current world

### DIFF
--- a/modules/people/manifests/annashipman.pp
+++ b/modules/people/manifests/annashipman.pp
@@ -12,7 +12,7 @@ class people::annashipman {
   class { 'teams::infrastructure': manage_gitconfig => false }
 
   include projects::deployment::creds
-  include projects::redirector
+  include projects::transition-config
 
   $home = "/Users/${::luser}"
   $projects = "${home}/projects"

--- a/modules/people/manifests/bradleywright.pp
+++ b/modules/people/manifests/bradleywright.pp
@@ -50,7 +50,7 @@ class people::bradleywright {
   include projects::govuk_frontend_toolkit
   include projects::private-utils
   include projects::puppet
-  include projects::redirector
+  include projects::transition-config
   include projects::router
   include projects::rummager
   include projects::smokey

--- a/modules/people/manifests/bruntonspall.pp
+++ b/modules/people/manifests/bruntonspall.pp
@@ -36,7 +36,7 @@ class people::bruntonspall {
   include projects::frontend
   include projects::govuk_frontend_toolkit
   include projects::private-utils
-  include projects::redirector
+  include projects::transition-config
   include projects::router
   include projects::rummager
   include projects::smokey

--- a/modules/people/manifests/jabley.pp
+++ b/modules/people/manifests/jabley.pp
@@ -51,7 +51,7 @@ class people::jabley(
   include projects::frontend
   include projects::govuk_content_api
   include projects::private-utils
-  include projects::redirector
+  include projects::transition-config
   include projects::router
   include projects::rummager
   include projects::whitehall

--- a/modules/people/manifests/jennyd.pp
+++ b/modules/people/manifests/jennyd.pp
@@ -29,7 +29,7 @@ class people::jennyd {
   include projects::opsmanual
   include projects::private-utils
   include projects::puppet
-  include projects::redirector
+  include projects::transition-config
   include projects::release
   include projects::rummager
   include projects::signonotron2

--- a/modules/projects/manifests/redirector.pp
+++ b/modules/projects/manifests/redirector.pp
@@ -1,4 +1,0 @@
-# Pulls the https://github.com/alphagov/redirector repository
-class projects::redirector {
-  repo::alphagov { 'redirector': }
-}

--- a/modules/projects/manifests/transition-config.pp
+++ b/modules/projects/manifests/transition-config.pp
@@ -1,0 +1,4 @@
+# Pulls the https://github.com/alphagov/transition-config repository
+class projects::transition-config {
+  repo::alphagov { 'transition-config': }
+}

--- a/modules/teams/manifests/transition.pp
+++ b/modules/teams/manifests/transition.pp
@@ -1,7 +1,7 @@
 class teams::transition {
   # Apps
   include projects::bouncer
-  include projects::redirector
+  include projects::transition-config
   include projects::side-by-side-browser
   include projects::transition
 


### PR DESCRIPTION
- In poking around team manifests, I found `projects::redirector`. Redirector is dead. Its purpose (and its name) was changed to transition-config, to reflect that it is now just a repository holding config for the Transition Tool.
- In changing the name of that project manifest file, I've also needed to change the name of the `include projects::redirector` to `include projects::transition-config` in people's manifests that contained that line so that next time they run Boxen, it completes successfully. If any of @bruntonspall, @bradleywright, @annashipman, @jabley or @jennyd object, speak now. :scream: 