### PR TITLE
Remove deprecated `concat::setup`

### DIFF
--- a/modules/ssh_config/manifests/init.pp
+++ b/modules/ssh_config/manifests/init.pp
@@ -1,7 +1,6 @@
 # manage user ssh config
 # uses puppetlabs-concat to enable separate sections to be managed separately
 class ssh_config {
-    include concat::setup
     $path = "/Users/${::luser}/.ssh/config"
     concat { $path:
       mode    => '0644',


### PR DESCRIPTION
Fixes this warning:

    Warning: Scope(Class[Concat::Setup]): concat::setup is deprecated
    as a public API of the concat module and should no longer be
    directly included in the manifest.