### PR TITLE
Remove agent forwarding from ci-new SSH config

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -5,7 +5,7 @@ Host ci-master.ci-govuk
   ProxyCommand none
 
 Host *.ci-govuk
-  ProxyCommand ssh -A -e none %r@ci-master.ci-govuk -W $(echo %h | sed 's/\.ci-govuk$//'):%p
+  ProxyCommand ssh -e none %r@ci-master.ci-govuk -W $(echo %h | sed 's/\.ci-govuk$//'):%p
 
 
 # Preview


### PR DESCRIPTION
Agent forwarding is undesirable because it exposes the use of your private
keys to other people that have root access to the remote machines. It's not
required when using `ProxyCommand` for a jumpbox like this.