### PR TITLE
Update draft environment SSH config

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -25,7 +25,7 @@ Host *.preview
 # Preview Draft
 # -------------
 Host jumpbox-1.management.preview-draft
-  Hostname jumpbox.draft.preview.alphagov.co.uk
+  Hostname jumpbox.draft.preview.publishing.service.gov.uk
   ProxyCommand none
 
 Host *.preview-draft
@@ -48,7 +48,7 @@ Host *.staging
 # Staging Draft
 # -------------
 Host jumpbox-1.management.staging-draft
-  Hostname jumpbox.draft.staging.alphagov.co.uk
+  Hostname jumpbox.draft.staging.publishing.service.gov.uk
   ProxyCommand none
 
 Host *.staging-draft
@@ -71,7 +71,7 @@ Host *.production
 # Production Draft
 # ----------------
 Host jumpbox-1.management.production-draft
-  Hostname jumpbox.draft.production.alphagov.co.uk
+  Hostname jumpbox.draft.production.publishing.service.gov.uk
   ProxyCommand none
 
 Host *.production-draft

--- a/modules/teams/manifests/infrastructure.pp
+++ b/modules/teams/manifests/infrastructure.pp
@@ -24,4 +24,12 @@ class teams::infrastructure ($manage_gitconfig = true) {
       'alias.st':     value => "status -bs";
     }
   }
+
+  package {
+    [
+      'ssh-copy-id',
+    ]:
+    ensure => present,
+  }
+
 }


### PR DESCRIPTION
These jumpbox hostnames were originally added before we decided to use `publishing.service.gov.uk`.