### PR TITLE
Update Alfred to 2.7.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -65,7 +65,7 @@ github "xquartz",     "1.2.1"
 # https://github.com/boxen.
 
 github "adium",          "1.4.0", :repo => "dieterdemeyer/puppet-adium"
-github "alfred",         "1.4.0"
+github "alfred",         "1.4.1", :repo => "heathd/puppet-alfred"
 github "android",        "1.4.0"
 github "antirsi",        "1.0.1", :repo => "norm/puppet-antirsi"
 github "atom",           "1.2.0"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -14,11 +14,6 @@ GITHUBTARBALL
     perl (1.1.0)
 
 GITHUBTARBALL
-  remote: boxen/puppet-alfred
-  specs:
-    alfred (1.4.0)
-
-GITHUBTARBALL
   remote: boxen/puppet-android
   specs:
     android (1.4.0)
@@ -404,6 +399,11 @@ GITHUBTARBALL
     mplayerx (1.0.0)
 
 GITHUBTARBALL
+  remote: heathd/puppet-alfred
+  specs:
+    alfred (1.4.1)
+
+GITHUBTARBALL
   remote: jabley/puppet-banshee
   specs:
     banshee (1.1.0)
@@ -475,7 +475,7 @@ GITHUBTARBALL
 
 DEPENDENCIES
   adium (= 1.4.0)
-  alfred (= 1.4.0)
+  alfred (= 1.4.1)
   android (= 1.4.0)
   antirsi (= 1.0.1)
   atom (= 1.2.0)


### PR DESCRIPTION
The zipfile for 2.5.1 has been removed and is no longer accessible (url returns 404).

I've [forked the `puppet-alfred` repo](https://github.com/heathd/puppet-alfred) to update this and [opened a PR](https://github.com/boxen/puppet-alfred/pull/32), but it might be a while until it gets merged.

Until then, use alfred from my fork.