### PR TITLE
Make version of gds_virtualbox configurable

### DIFF
--- a/modules/gds_virtualbox/manifests/init.pp
+++ b/modules/gds_virtualbox/manifests/init.pp
@@ -4,6 +4,15 @@
 #
 #   include gds_virtualbox
 
-class gds_virtualbox {
-  include gds_virtualbox::recommended
+class gds_virtualbox($version = 'recommended') {
+  case $version {
+    '4.3.26':  { $url = 'http://download.virtualbox.org/virtualbox/4.3.26/VirtualBox-4.3.26-98988-OSX.dmg' }
+    '4.2.22':  { $url = 'http://download.virtualbox.org/virtualbox/4.2.22/VirtualBox-4.2.22-91556-OSX.dmg' }
+    default:   { $url = 'http://download.virtualbox.org/virtualbox/4.3.14/VirtualBox-4.3.14-95030-OSX.dmg' }
+  }
+
+  package { "VirtualBox":
+    provider => 'pkgdmg',
+    source   => $url
+  }
 }

--- a/modules/gds_virtualbox/manifests/recommended.pp
+++ b/modules/gds_virtualbox/manifests/recommended.pp
@@ -1,6 +1,0 @@
-class gds_virtualbox::recommended {
-  package { 'VirtualBox':
-    provider => 'pkgdmg',
-    source   => 'http://download.virtualbox.org/virtualbox/4.3.14/VirtualBox-4.3.14-95030-OSX.dmg'
-  }
-}


### PR DESCRIPTION
note that it will not auto-upgrade as the pkgdmg provider does not support versioning.

You'll need to remove /var/db/.puppet_pkgdmg_installed_VirtualBox to force an upgrade