### PR TITLE
[jabley] configure `$HOME/.fabricrc`

### DIFF
--- a/modules/people/manifests/jabley.pp
+++ b/modules/people/manifests/jabley.pp
@@ -214,6 +214,12 @@ class people::jabley(
     ensure => directory,
   }
 
+  file { "${::luser}-fabricrc":
+    path    => "$home/.fabricrc",
+    ensure  => 'file',
+    content => 'user = jabley',
+  }
+
   $dotfiles = "${home_projects}/homedir"
 
   repository { $dotfiles:


### PR DESCRIPTION
Doing this at a global level, rather than scoping on a per-host basis in
`$HOME/ssh/config` since we don’t do that currently.