### PR TITLE
Use specific printer driver

### DIFF
--- a/modules/gds_printers/manifests/init.pp
+++ b/modules/gds_printers/manifests/init.pp
@@ -4,6 +4,7 @@
 # from your local login username.
 #
 class gds_printers (
+  $driver_3_il0 = 'drv:///sample.drv/generic.ppd',
   $ldap_username = $::boxen_user,
 ) {
   printer { 'Secure_Printer_4':
@@ -23,7 +24,7 @@ class gds_printers (
     description => '3rd Floor IL0 Printer',
     location    => '3rd floor, Aviation House',
     uri         => "lpd://${ldap_username}@192.168.9.47/FollowPrint",
-    model       => '/Library/Printers/PPDs/Contents/Resources/Xerox WorkCentre 7855.gz',
+    model       => $driver_3_il0,
     page_size   => 'A4',
     ppd_options => {
       'Option1' => 'True', # Duplexer

--- a/modules/gds_printers/manifests/init.pp
+++ b/modules/gds_printers/manifests/init.pp
@@ -23,7 +23,7 @@ class gds_printers (
     description => '3rd Floor IL0 Printer',
     location    => '3rd floor, Aviation House',
     uri         => "lpd://${ldap_username}@192.168.9.47/FollowPrint",
-    model       => 'drv:///sample.drv/generic.ppd',
+    model       => '/Library/Printers/PPDs/Contents/Resources/Xerox WorkCentre 7855.gz',
     page_size   => 'A4',
     ppd_options => {
       'Option1' => 'True', # Duplexer


### PR DESCRIPTION
Using the preferred printer driver should give better printer output,
and allow printer-specific options to be used when configuring.
This change gives more control to the end user.

Note: the driver may need to be installed via munki, in which case we
should not merge this. Not everyone currently has a managed machine.