### PR TITLE
Add example for new Carrenza Staging SSH config.

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -23,7 +23,7 @@ Host *.preview
   ProxyCommand ssh -e none %r@jumpbox-1.management.preview -W $(echo %h | sed 's/\.preview$//'):%p
 
 
-# Staging
+# Staging ( Skyscape )
 # -------
 Host jumpbox-1.management.staging
   Hostname jumpbox.staging.alphagov.co.uk
@@ -38,7 +38,7 @@ Host *.staging
   ProxyCommand ssh -e none %r@jumpbox-1.management.staging -W $(echo %h | sed 's/\.staging$//'):%p
 
 
-# Production
+# Production ( Skyscape )
 # ----------
 Host jumpbox-1.management.production
   Hostname jumpbox.production.alphagov.co.uk
@@ -51,3 +51,17 @@ Host jumpbox-2.management.production
 
 Host *.production
   ProxyCommand ssh -e none %r@jumpbox-1.management.production -W $(echo %h | sed 's/\.production$//'):%p
+
+
+# Carrenza Migration ( Staging + Production )
+Host jumpbox.staging.publishing.service.gov.uk
+  ProxyCommand none
+
+Host *.staging.publishing.service.gov.uk
+  ProxyCommand ssh -e none %r@jumpbox.staging.publishing.service.gov.uk -W %h:%p
+
+Host jumpbox.publishing.service.gov.uk
+  ProxyCommand none
+
+Host *.publishing.service.gov.uk
+  ProxyCommand ssh -e none %r@jumpbox.publishing.service.gov.uk -W %h:%p


### PR DESCRIPTION
People will need to update their SSH config for Carrenza migration, add example here as this is where the [opsmanual](https://github.gds/pages/gds/opsmanual/2nd-line/technical-setup.html?highlight=ssh%20config) points to.