### PR TITLE
Switch staging to use new domain

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -26,11 +26,11 @@ Host *.preview
 # Staging
 # -------
 Host jumpbox-1.management.staging
-  Hostname jumpbox.staging.alphagov.co.uk
+  Hostname jumpbox.staging.publishing.service.gov.uk
   ProxyCommand none
 
 Host jumpbox-2.management.staging
-  Hostname jumpbox.staging.alphagov.co.uk
+  Hostname jumpbox.staging.publishing.service.gov.uk
   Port     1022
   ProxyCommand none
 


### PR DESCRIPTION
This is the minimum change required to make the staging SSH config work.

#180 changes the hostname used to connect to machines to make it much longer, which is something I don't know if we want to do.