### PR TITLE
Add disaster recovery VPN configuration

### DIFF
--- a/modules/gds_vpn_profiles/files/profile/gds_dr_github.xml
+++ b/modules/gds_vpn_profiles/files/profile/gds_dr_github.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnyConnectProfile xmlns="http://schemas.xmlsoap.org/encoding/">
+  <ServerList>
+    <HostEntry>
+      <HostName>GDS (DR) - GitHub</HostName>
+      <HostAddress>vpndr.digital.cabinet-office.gov.uk</HostAddress>
+      <UserGroup>github</UserGroup>
+      <PrimaryProtocol>SSL</PrimaryProtocol>
+    </HostEntry>
+  </ServerList>
+</AnyConnectProfile>

--- a/modules/gds_vpn_profiles/files/profile/gds_dr_route.xml
+++ b/modules/gds_vpn_profiles/files/profile/gds_dr_route.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnyConnectProfile xmlns="http://schemas.xmlsoap.org/encoding/">
+  <ServerList>
+    <HostEntry>
+      <HostName>GDS (DR) - Default Route</HostName>
+      <HostAddress>vpndr.digital.cabinet-office.gov.uk</HostAddress>
+      <UserGroup>ah</UserGroup>
+      <PrimaryProtocol>SSL</PrimaryProtocol>
+    </HostEntry>
+  </ServerList>
+</AnyConnectProfile>


### PR DESCRIPTION
These aren’t enabled all the time, but when you need them, it’s good to
have them set up.