### PR TITLE
Update SSH config post-migration

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -23,7 +23,7 @@ Host *.preview
   ProxyCommand ssh -e none %r@jumpbox-1.management.preview -W $(echo %h | sed 's/\.preview$//'):%p
 
 
-# Staging ( Skyscape )
+# Staging
 # -------
 Host jumpbox-1.management.staging
   Hostname jumpbox.staging.publishing.service.gov.uk
@@ -38,14 +38,14 @@ Host *.staging
   ProxyCommand ssh -e none %r@jumpbox-1.management.staging -W $(echo %h | sed 's/\.staging$//'):%p
 
 
-# Production ( Skyscape )
+# Production
 # ----------
 Host jumpbox-1.management.production
-  Hostname jumpbox.production.alphagov.co.uk
+  Hostname jumpbox.publishing.service.gov.uk
   ProxyCommand none
 
 Host jumpbox-2.management.production
-  Hostname jumpbox.production.alphagov.co.uk
+  Hostname jumpbox.publishing.service.gov.uk
   Port 1022
   ProxyCommand none
 
@@ -53,7 +53,8 @@ Host *.production
   ProxyCommand ssh -e none %r@jumpbox-1.management.production -W $(echo %h | sed 's/\.production$//'):%p
 
 
-# Carrenza Migration ( Staging + Production )
+# FQDNs
+# -----
 Host jumpbox.staging.publishing.service.gov.uk
   ProxyCommand none
 


### PR DESCRIPTION
This should be merged when `jumpbox.production.alphagov.co.uk` is switched off.

- Remove supplier names because we don't need them anymore
- Update production jumpbox domain