### PR TITLE
Rationalise SSH configuration

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -22,9 +22,14 @@ Host jumpbox-2.management.preview
 Host *.preview
   ProxyCommand ssh -e none %r@jumpbox-1.management.preview -W $(echo %h | sed 's/\.preview$//'):%p
 
-
-# Staging ( Skyscape )
+# Staging
 # -------
+Host jumpbox.staging.publishing.service.gov.uk
+  ProxyCommand none
+
+Host *.staging.publishing.service.gov.uk
+  ProxyCommand ssh -e none %r@jumpbox.staging.publishing.service.gov.uk -W %h:%p
+
 Host jumpbox-1.management.staging
   Hostname jumpbox.staging.publishing.service.gov.uk
   ProxyCommand none
@@ -37,31 +42,22 @@ Host jumpbox-2.management.staging
 Host *.staging
   ProxyCommand ssh -e none %r@jumpbox-1.management.staging -W $(echo %h | sed 's/\.staging$//'):%p
 
-
-# Production ( Skyscape )
+# Production
 # ----------
-Host jumpbox-1.management.production
-  Hostname jumpbox.production.alphagov.co.uk
-  ProxyCommand none
-
-Host jumpbox-2.management.production
-  Hostname jumpbox.production.alphagov.co.uk
-  Port 1022
-  ProxyCommand none
-
-Host *.production
-  ProxyCommand ssh -e none %r@jumpbox-1.management.production -W $(echo %h | sed 's/\.production$//'):%p
-
-
-# Carrenza Migration ( Staging + Production )
-Host jumpbox.staging.publishing.service.gov.uk
-  ProxyCommand none
-
-Host *.staging.publishing.service.gov.uk
-  ProxyCommand ssh -e none %r@jumpbox.staging.publishing.service.gov.uk -W %h:%p
-
 Host jumpbox.publishing.service.gov.uk
   ProxyCommand none
 
 Host *.publishing.service.gov.uk
   ProxyCommand ssh -e none %r@jumpbox.publishing.service.gov.uk -W %h:%p
+
+Host jumpbox-1.management.production
+  Hostname jumpbox.publishing.service.gov.uk
+  ProxyCommand none
+
+Host jumpbox-2.management.production
+  Hostname jumpbox.publishing.service.gov.uk
+  Port     1022
+  ProxyCommand none
+
+Host *.production
+  ProxyCommand ssh -e none %r@jumpbox-1.management.production -W $(echo %h | sed 's/\.production$//'):%p


### PR DESCRIPTION
- Changes Carrenza sections to just "staging" and "production" (it's all
  Carrenza)
- Adds a shortcut so that `host-n.vdc.production` will SSH into new production