### PR TITLE
Add ssh config for new CI hostname

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -7,6 +7,9 @@ Host ci-master.ci-govuk
 Host *.ci-govuk
   ProxyCommand ssh -e none %r@ci-master.ci-govuk -W $(echo %h | sed 's/\.ci-govuk$//'):%p
 
+Host ci.dev.publishing.service.gov.uk
+  ProxyCommand none
+
 
 # Preview
 # -------


### PR DESCRIPTION
Our CI environment has recently moved to `ci.dev.publishing.service.gov.uk`.
Our deployment scripts for ci-puppet need to be able to ssh to this hostname,
but the ssh config here for our Production environment tries to send
everything at `*.publishing.service.gov.uk` through the Production jumpbox,
which makes the ci-puppet deployment fail.

Adding this bit of config above the wildcard Production section resolves this
issue, allowing our deployment script for ci-puppet to work.