### PR TITLE
Add rooms VPN profile

### DIFF
--- a/modules/gds_vpn_profiles/files/profile/gds_mrt.xml
+++ b/modules/gds_vpn_profiles/files/profile/gds_mrt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnyConnectProfile xmlns="http://schemas.xmlsoap.org/encoding/">
+  <ServerList>
+    <HostEntry>
+      <HostName>GDS - MRT</HostName>
+      <HostAddress>vpn.digital.cabinet-office.gov.uk</HostAddress>
+      <UserGroup>dmzmrt</UserGroup>
+      <PrimaryProtocol>SSL</PrimaryProtocol>
+    </HostEntry>
+  </ServerList>
+</AnyConnectProfile>


### PR DESCRIPTION
The applications for the tablet room booking systems run on this VPN.
I did define it locally, but it gets deleted whenever I run boxen. So
I’m putting it in boxen.