### PR TITLE
Add `UseRoaming no` to SSH config

### DIFF
--- a/modules/gds_ssh_config/files/gds_ssh_config
+++ b/modules/gds_ssh_config/files/gds_ssh_config
@@ -1,3 +1,6 @@
+Host *
+  UseRoaming no
+
 # CI
 # --
 Host ci-master.ci-govuk


### PR DESCRIPTION
There is a security vulnerability incoming: https://twitter.com/msfriedl/status/687635945642967040

> Add undocumented "UseRoaming no" to ssh_config or use "-oUseRoaming=no" to prevent upcoming #openssh client bug CVE-2016-0777. More later.