### PR TITLE
Add recent default Ruby versions

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -1,2 +1,3 @@
 ---
 alfred::version: '2.7.1_387'
+ruby::build::ensure: 'origin/HEAD'

--- a/modules/gds_ruby/manifests/init.pp
+++ b/modules/gds_ruby/manifests/init.pp
@@ -19,8 +19,8 @@
 #           1.8.7: 1.9.3-p545
 #
 class gds_ruby (
-  $versions   = ['1.8.7','1.9.3','2.0.0','2.1.0','2.1.2'],
-  $uninstall_versions = ['2.1.1'],
+  $versions   = ['1.9.3','2.0.0','2.1.8','2.2.4', '2.3.0'],
+  $uninstall_versions = ['2.1.0', '2.1.2'],
 ) {
 
   include ruby


### PR DESCRIPTION
Update the default list of Ruby versions that we install to use the
latest version in each stable branch.

So that we can install these versions, ensure that the `ruby-build` repo
is tracking the tip of the master branch by setting
`ruby::build::ensure` in `common.yaml`. I think the small risk posed by
us tracking an unreleased check-out of `ruby-build` is outweighed by the
convenience of not having to upgrade this every time we need a more
recent Ruby version.

Uninstall older versions from the stable branches that are no longer
current.

Anyone wishing to continue to use old versions can do so by overriding
this list in Hiera data, as has been done in dff6b154c.

I've removed 2.1.1 from the uninstall list on the assumption that it
has been in the codebase long enough for it to have been removed
already. It was first removed in 07fe8438.