### PR TITLE
Update script to work on El Capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     # If your project directory is not /Users/$USER/govuk/ then use
     # PATH=... script/boxen --srcdir=/path/to/project/directory
     # For a fresh build, you will need to create /project/directory
-    PATH=/usr/bin:/bin:/usr/sbin:/sbin script/boxen --srcdir=/Users/${USER}/govuk
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin script/boxen --srcdir=/Users/${USER}/govuk
     # add boxen to your shell config, at the end, eg.
     echo '[ -f /opt/boxen/env.sh ] && source /opt/boxen/env.sh' >> ~/.bashrc
     # or if you use ZSH


### PR DESCRIPTION
Could not run the script on my laptop with El Capitan installed. We found out that El Capitan's /bin folder can be found at:
`/usr/local/bin`

Updating the script to save some time to the next person that will try to install GDS boxen on El Capitan.