### PR TITLE
Remove perl

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -106,7 +106,6 @@ github "onepassword",    "1.1.5"
 github "omnigraffle",    "1.3.1"
 github "osx",            "2.8.0"
 github "packer",         "1.3.0"
-github "perl",           "1.1.0", :repo => "boxelly/puppet-perl"
 github "postgresql",     "3.0.3"                      # Note: this version installs postgresql 9.3.2
 github "propane",        "0.0.1", :repo => "technicalpickles/puppet-propane"
 github "pycharm",        "1.0.4"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -9,11 +9,6 @@ GITHUBTARBALL
     python (1.1.2)
 
 GITHUBTARBALL
-  remote: boxelly/puppet-perl
-  specs:
-    perl (1.1.0)
-
-GITHUBTARBALL
   remote: boxen/puppet-alfred
   specs:
     alfred (1.4.0)
@@ -531,7 +526,6 @@ DEPENDENCIES
   openssl (= 1.0.0)
   osx (= 2.8.0)
   packer (= 1.3.0)
-  perl (= 1.1.0)
   phantomjs (= 3.0.0)
   pkgconfig (= 1.0.0)
   postgresql (= 3.0.3)
@@ -570,4 +564,3 @@ DEPENDENCIES
   x_dispatch (= 2.0.0)
   xquartz (= 1.2.1)
   zsh (= 1.0.0)
-

--- a/modules/people/manifests/rjw1.pp
+++ b/modules/people/manifests/rjw1.pp
@@ -60,13 +60,7 @@ package {
     ensure => present,
     provider => pip,
   }
-  # Perl
-  class { 'perl::global':
-      version => '5.18.2'
-  }
-  perl::version { '5.18.2': }
 
   vim::bundle { 'rodjek/vim-puppet': }
   vim::bundle { 'godlygeek/tabular': }
 }
-


### PR DESCRIPTION
The `boxelly/puppet-perl` repo has been removed (the entire boxelly account actually) so this is preventing new starters from running boxen.

Sorry @rjw1! Do you know an alternative? 