### PR TITLE
bump default bundler for rubies

### DIFF
--- a/modules/gds_ruby/manifests/init.pp
+++ b/modules/gds_ruby/manifests/init.pp
@@ -36,7 +36,7 @@ class gds_ruby (
 
   ruby_gem { 'bundler for all rubies':
     gem          => 'bundler',
-    version      => '~> 1.5.3',
+    version      => '~> 1.14.5',
     ruby_version => '*',
   }
 }


### PR DESCRIPTION
1.5.* is super old - the last 1.5 version was 1.5.3 in February 2014.

This bumps the default version to be the latest.