### PR TITLE
Update GHE domain name

### DIFF
--- a/modules/repo/manifests/gds.pp
+++ b/modules/repo/manifests/gds.pp
@@ -1,5 +1,5 @@
 define repo::gds {
   repository { "${boxen::config::srcdir}/${title}":
-    source   => "git@github.gds:gds/${title}",
+    source   => "git@github.digital.cabinet-office.gov.uk:gds/${title}",
   }
 }


### PR DESCRIPTION
This commit updates the GHE domain name from `github.gds` to `github.digital.cabinet-office.gov.uk`.

Trello: https://trello.com/c/aTAoiXAm/281-github-enterprise-new-domain-name