### PR TITLE
Remove the Content API

### DIFF
--- a/modules/people/manifests/heathd.pp
+++ b/modules/people/manifests/heathd.pp
@@ -40,7 +40,6 @@ class people::heathd {
   include projects::frontend
   include projects::gds-api-adapters
   include projects::gds-sso
-  include projects::govuk_content_api
   include projects::govuk_mirror
   include projects::opsmanual
   include projects::puppet

--- a/modules/people/manifests/jennyd.pp
+++ b/modules/people/manifests/jennyd.pp
@@ -34,7 +34,6 @@ class people::jennyd {
   include projects::frontend
   include projects::gds-api-adapters
   include projects::gds-sso
-  include projects::govuk_content_api
   include projects::govuk_mirror-deployment
   include projects::govuk_offsitebackups-puppet
   include projects::imminence

--- a/modules/projects/manifests/govuk_content_api.pp
+++ b/modules/projects/manifests/govuk_content_api.pp
@@ -1,4 +1,0 @@
-# Pulls the https://github.com/alphagov/govuk_content_api repository
-class projects::govuk_content_api {
-  repo::alphagov { 'govuk_content_api': }
-}


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api
